### PR TITLE
OSX: Fix link error on unfound boost libraries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -275,20 +275,20 @@ script:
   - ctest -j 3 --output-on-failure
 #
 # linux only (add qt5 after qt4 in the same job) :
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then if [[ "$DOC" == "false" ]]; then sudo apt-get -y install qtbase5-dev qt5-default; fi; fi # ---> now install qt5
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then if [[ "$DOC" == "false" ]]; then cd ..; fi; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then if [[ "$DOC" == "false" ]]; then mkdir build_linux_qt5 && cd build_linux_qt5 && cmake .. $BTYPE -DBUILD_USE_QT5=YES; fi; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then if [[ "$DOC" == "false" ]]; then make -j 3; fi; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then if [[ "$DOC" == "false" ]]; then ctest -j 3 --output-on-failure; fi; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then if [[ "$DOC" == "false" ]]; then sudo apt-get -y install qtbase5-dev qt5-default; fi; fi # ---> now install qt5
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then if [[ "$DOC" == "false" ]]; then cd ..; fi; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then if [[ "$DOC" == "false" ]]; then mkdir build_linux_qt5 && cd build_linux_qt5 && cmake .. $BTYPE -DBUILD_USE_QT5=YES; fi; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then if [[ "$DOC" == "false" ]]; then make -j 3; fi; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then if [[ "$DOC" == "false" ]]; then ctest -j 3 --output-on-failure; fi; fi
 #
 # osx only (add qt5 after qt4 in the same job) :
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then brew unlink qt@4; fi; fi # ---> now unlink qt4
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then brew install qt; fi; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then brew link qt --force; fi; fi # ---> now link qt5
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then cd ..; fi; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then mkdir build_osx_qt5 && cd build_osx_qt5 && /tmp/cmake-3.4.3-Darwin-x86_64/CMake.app/Contents/bin/cmake .. $BTYPE -DBUILD_USE_QT5=YES -DQT5_DIR=/usr/local/opt/qt5; fi; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then make -j 3; fi; fi # ---> travis_wait 60 make ?
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then ctest -j 3 --output-on-failure; fi; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then brew unlink qt@4; fi; fi # ---> now unlink qt4
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then brew install qt; fi; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then brew link qt --force; fi; fi # ---> now link qt5
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then cd ..; fi; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then mkdir build_osx_qt5 && cd build_osx_qt5 && /tmp/cmake-3.4.3-Darwin-x86_64/CMake.app/Contents/bin/cmake .. $BTYPE -DBUILD_USE_QT5=YES -DQT5_DIR=/usr/local/opt/qt5; fi; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then make -j 3; fi; fi # ---> travis_wait 60 make ?
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [[ "$DOC" == "false" ]]; then ctest -j 3 --output-on-failure; fi; fi
 #
 # building the documentation
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ sudo: required # need by trusty
 dist: trusty # Ubuntu 14.04 LTS
 #group: deprecated-2017Q4
 
-#osx_image: xcode10 # Xcode 10.0 under High Sierra (OS X 10.13)
-osx_image: xcode9.4 # Xcode 9.4.1 under High Sierra (OS X 10.13)
+osx_image: xcode10 # Xcode 10.0 under High Sierra (OS X 10.13)
+#osx_image: xcode9.4 # Xcode 9.4.1 under High Sierra (OS X 10.13)
 #osx_image: xcode9.3 # Xcode 9.3 under High Sierra (OS X 10.13)
 #osx_image: xcode9.2 # Xcode 9.2 under Sierra (OS X 10.12)
 #osx_image: xcode8.3 # Xcode 8.3.3 under Sierra (OS X 10.12)

--- a/.travis.yml
+++ b/.travis.yml
@@ -219,12 +219,12 @@ install:
 #  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cgal; fi # ---> install cgal 4.11.1
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew info cgal; fi # to show cgal version
 # -> BEGIN patch for cgal 4.11 bug - missing 2x inline in 2 headers - (NO MORE PROBLEM with version >= 4.11.1)
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /usr/local/include/CGAL/boost/graph; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mv io.h io.h.old; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget --no-check-certificate https://download.gforge.liris.cnrs.fr/meppbin/src/cgal411/io.h; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mv cgal_bgl_graph_io.h cgal_bgl_graph_io.h.old; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget --no-check-certificate https://download.gforge.liris.cnrs.fr/meppbin/src/cgal411/cgal_bgl_graph_io.h; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd $TRAVIS_BUILD_DIR; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd /usr/local/include/CGAL/boost/graph; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mv io.h io.h.old; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget --no-check-certificate https://download.gforge.liris.cnrs.fr/meppbin/src/cgal411/io.h; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mv cgal_bgl_graph_io.h cgal_bgl_graph_io.h.old; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget --no-check-certificate https://download.gforge.liris.cnrs.fr/meppbin/src/cgal411/cgal_bgl_graph_io.h; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd $TRAVIS_BUILD_DIR; fi
 # -> END patch for cgal 4.11 bug - missing 2x inline in 2 headers - (NO MORE PROBLEM with version >= 4.11.1)
 #
 # ---> because we want osg34 under osx !!!

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ sudo: required # need by trusty
 dist: trusty # Ubuntu 14.04 LTS
 #group: deprecated-2017Q4
 
-osx_image: xcode9.3 # Xcode 9.3 under High Sierra (OS X 10.13)
+#osx_image: xcode10 # Xcode 10.0 under High Sierra (OS X 10.13)
+osx_image: xcode9.4 # Xcode 9.4.1 under High Sierra (OS X 10.13)
+#osx_image: xcode9.3 # Xcode 9.3 under High Sierra (OS X 10.13)
 #osx_image: xcode9.2 # Xcode 9.2 under Sierra (OS X 10.12)
 #osx_image: xcode8.3 # Xcode 8.3.3 under Sierra (OS X 10.12)
 #osx_image: xcode7.3 # Xcode 7.3.1 under El Capitan (OS X 10.11)

--- a/Cmake/FindDependencies.cmake
+++ b/Cmake/FindDependencies.cmake
@@ -1,29 +1,10 @@
-##### Boost is a must unless when building the documentation only
-if( BUILD_USE_CGAL OR BUILD_USE_OPENMESH OR BUILD_USE_AIF )
-  find_package(Boost COMPONENTS thread system filesystem REQUIRED)
-  if(Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS})
-  endif(Boost_FOUND)
-endif()
-
-##### EIGEN3
-if (WIN32)
-	if(DEFINED ENV{EIGEN3_INCLUDE_DIR})
-		SET( EIGEN3_INCLUDE_DIR $ENV{EIGEN3_INCLUDE_DIR} )
-	ENDIF()
-endif (WIN32)
-# Eigen is needed except for the documentation
-if( BUILD_USE_CGAL OR BUILD_USE_OPENMESH OR BUILD_USE_AIF )
-	FIND_PACKAGE(Eigen3)
-	if(EIGEN3_FOUND)
-	  INCLUDE_DIRECTORIES(${EIGEN3_INCLUDE_DIR})
-	ELSE(EIGEN3_FOUND)
-	  MESSAGE(FATAL_ERROR
-			  "Eigen3 not found. Please set EIGEN3_INCLUDE_DIR to the root directory of your Eigen3 installation.")
-	endif(EIGEN3_FOUND)
-endif()
 
 ##### CGAL package finding
+# Caveat emptor: for some undocummented reason CGAL package detection messes
+#     up (it clears it completely at least on OSX) the content of the
+#     Boot_LIBRAIRES variable as set up by the Boot package detection.
+#     In order to avoid this side effect, CGAL package detection must be
+#     placed BEFORE Boost package detection.
 if( BUILD_USE_CGAL )
   add_definitions( -DCGAL_EIGEN3_ENABLED ) ##### SOME CGAL FUNCTIONALITIES DEPEND ON EIGEN3
 
@@ -62,6 +43,31 @@ else()
   add_definitions( -DCGAL_NO_AUTOLINK_CGAL )
   add_definitions( -DCGAL_NDEBUG )
   message ( STATUS "Use local LGPL CGAL")
+endif()
+
+##### Boost is a must unless when building the documentation only
+if( BUILD_USE_CGAL OR BUILD_USE_OPENMESH OR BUILD_USE_AIF )
+  find_package(Boost COMPONENTS thread system filesystem REQUIRED)
+  if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIRS})
+  endif(Boost_FOUND)
+endif()
+
+##### EIGEN3
+if (WIN32)
+	if(DEFINED ENV{EIGEN3_INCLUDE_DIR})
+		SET( EIGEN3_INCLUDE_DIR $ENV{EIGEN3_INCLUDE_DIR} )
+	ENDIF()
+endif (WIN32)
+# Eigen is needed except for the documentation
+if( BUILD_USE_CGAL OR BUILD_USE_OPENMESH OR BUILD_USE_AIF )
+	FIND_PACKAGE(Eigen3)
+	if(EIGEN3_FOUND)
+	  INCLUDE_DIRECTORIES(${EIGEN3_INCLUDE_DIR})
+	ELSE(EIGEN3_FOUND)
+	  MESSAGE(FATAL_ERROR
+			  "Eigen3 not found. Please set EIGEN3_INCLUDE_DIR to the root directory of your Eigen3 installation.")
+	endif(EIGEN3_FOUND)
 endif()
 
 ##### OpenMesh package finding

--- a/Cmake/FindDependencies.cmake
+++ b/Cmake/FindDependencies.cmake
@@ -1,8 +1,7 @@
-
 ##### CGAL package finding
-# Caveat emptor: for some undocummented reason CGAL package detection messes
+# Caveat emptor: for some undocumented reason CGAL package detection messes
 #     up (it clears it completely at least on OSX) the content of the
-#     Boot_LIBRAIRES variable as set up by the Boot package detection.
+#     Boost_LIBRARIES variable as set up by the Boost package detection.
 #     In order to avoid this side effect, CGAL package detection must be
 #     placed BEFORE Boost package detection.
 if( BUILD_USE_CGAL )


### PR DESCRIPTION
Proposition to fix link error (that appears on the first target test_decompression_valence_lcc) against 
boost libraries and that goes:
```
[  3%] Linking CXX executable test_decompression_valence_lcc
Undefined symbols for architecture x86_64:
  "boost::filesystem::detail::copy_file(boost::filesystem::path const&, boost::filesystem::path const&, boost::filesystem::detail::copy_option, boost::system::error_code*)", referenced from:
      FEVV::FileUtils::copy_file(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in test_decompression_valence_lcc.cpp.o
```
Although the manifestation is [simillar to this stackoverflow](https://stackoverflow.com/questions/35007134/c-boost-undefined-reference-to-boostfilesystemdetailcopy-file), it look like the problem
for MEPP2 is due to a strange side effect of `FindPackage( CGAL )` within cmake...